### PR TITLE
bgcolor not supported in html5; switch to css

### DIFF
--- a/R/htmlTable.R
+++ b/R/htmlTable.R
@@ -774,7 +774,7 @@ htmlTable <- function(x,
         
         ## this will allow either rgroupCSSstyle or altcol to 
         ## color the rgroup label rows
-        table_str <- sprintf("%s\n\t<tr bgcolor=%s><td colspan='%d' style='%s'>%s</td></tr>", table_str, 
+        table_str <- sprintf("%s\n\t<tr style='background-color:%s;'><td colspan='%d' style='%s'>%s</td></tr>", table_str, 
                              rep(unique(rs2), length(rgroup))[rgroup_iterator],
                              total_columns, 
                              rs,
@@ -784,7 +784,7 @@ htmlTable <- function(x,
     
     if (!missing(rgroup)){
       ## this will change the bgcolor of the rows, by rgroup
-      table_str <- sprintf("%s\n\t<tr bgcolor=%s>", table_str, rs2[row_nr])
+      table_str <- sprintf("%s\n\t<tr style='background-color:%s;'>", table_str, rs2[row_nr])
     }else{
       table_str <- sprintf("%s\n\t<tr>", table_str)
     }


### PR DESCRIPTION
tested by copy/paste and opening .html with word processors

osx
- libre office 4.2.4
- open office 4.1.0

windows
- word 2010
- libre office 4.2.4
- open office 4.1.0
