### PR TITLE
typo fix

### DIFF
--- a/R/htmlTable.R
+++ b/R/htmlTable.R
@@ -450,7 +450,7 @@ htmlTable <- function(x,
 
     if(sum(n.tspanner) !=  nrow(x))
       stop(sprintf("Your rows don't match in the n.tspanner, i.e. %d != %d",
-                   sum(n.rgroup), nrow(x)))
+                   sum(n.tspanner), nrow(x)))
 
     # Make sure there are no collisions with rgrou
     if (!missing(n.rgroup)){


### PR DESCRIPTION
When `sum(n.tspanner) != nrow(data)`, if `n.rgroup` isn't given we get this uninformative error below.

``` r
library(Gmisc)

htmlTable(mtcars, n.tspanner = c(1, 32), tspanner = c('one','two'))
```

```
Error in sprintf("Your rows don't match in the n.tspanner, i.e. %d != %d",  : 
   argument "n.rgroup" is missing, with no default 
```

After the change:             

``` r
htmlTable(mtcars, n.tspanner = c(1, 32), tspanner = c('one','two'))
```

```
Error in htmlTable(mtcars, n.tspanner = c(1, 32), tspanner = c("one",  : 
  Your rows don't match in the n.tspanner, i.e. 33 != 32
```
