### PR TITLE
Fix issue #21: some but not all values missing in output row 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@
 language: r
 warnings_are_errors: true
 sudo: required
+
+before_install:
+  Rscript -e 'update.packages(ask = FALSE)'

--- a/R/getDescriptionStatsBy.R
+++ b/R/getDescriptionStatsBy.R
@@ -295,7 +295,7 @@ getDescriptionStatsBy <- function(x,
     ret <- list()
     for (n in names(t)){
       # Create an empty array
-      ret[[n]] <- rep(0, times=length(all_row_names))
+      ret[[n]] <- rep("-", times=length(all_row_names))
       names(ret[[n]]) <- all_row_names
       # Loop and add all the values
       for (nn in all_row_names){
@@ -329,7 +329,13 @@ getDescriptionStatsBy <- function(x,
               useNA.digits = useNA.digits,
               percentage_sign = percentage_sign)
 
-
+    missing_t <- sapply(t, is.null)
+    if (any(missing_t)) {
+      substitute_t <- rep("-", length(t[!missing_t][[1]]))
+      names(substitute_t) <- names(t[!missing_t][[1]])
+      t[missing_t][[1]] <- substitute_t
+    }
+    
     if (length(t[[1]]) != 1){
       fn_name <- deparse(substitute(continuous_fn))
       if (fn_name == "describeMean")

--- a/R/getDescriptionStatsBy.R
+++ b/R/getDescriptionStatsBy.R
@@ -87,6 +87,7 @@
 #'  e.g. Smoking; No. 25 observations, where there is a new line after the
 #'  factor name. If you want a different text for the second line you can
 #'  specifically use the \code{\link[base]{sprintf}} formatting, e.g. "No. \%s patients".
+#' @param missing_value Value that is substituted for empty cells. Defaults to "-"  
 #' @param ... Currently only used for generating warnings of deprecated call
 #'  parameters.
 #' @return Returns a vector if vars wasn't specified and it's a
@@ -126,6 +127,7 @@ getDescriptionStatsBy <- function(x,
                                   NEJMstyle = FALSE,
                                   percentage_sign = TRUE,
                                   header_count,
+                                  missing_value = "-",
                                   ...){
 
   API_changes <-
@@ -295,7 +297,7 @@ getDescriptionStatsBy <- function(x,
     ret <- list()
     for (n in names(t)){
       # Create an empty array
-      ret[[n]] <- rep("-", times=length(all_row_names))
+      ret[[n]] <- rep(missing_value, times=length(all_row_names))
       names(ret[[n]]) <- all_row_names
       # Loop and add all the values
       for (nn in all_row_names){
@@ -331,7 +333,7 @@ getDescriptionStatsBy <- function(x,
 
     missing_t <- sapply(t, is.null)
     if (any(missing_t)) {
-      substitute_t <- rep("-", length(t[!missing_t][[1]]))
+      substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
       names(substitute_t) <- names(t[!missing_t][[1]])
       t[missing_t][[1]] <- substitute_t
     }
@@ -361,6 +363,13 @@ getDescriptionStatsBy <- function(x,
             useNA.digits = useNA.digits,
             default_ref = default_ref, percentage_sign = percentage_sign)
 
+    missing_t <- sapply(t, is.null)
+    if (any(missing_t)) {
+      substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
+      names(substitute_t) <- names(t[!missing_t][[1]])
+      t[missing_t][[1]] <- substitute_t
+    }
+    
     # Check that we're dealing with only one row
     if (unique(sapply(t, length)) == 1)
       # Set the rowname to a special format
@@ -402,6 +411,12 @@ getDescriptionStatsBy <- function(x,
               useNA = useNA,
               useNA.digits = useNA.digits,
               percentage_sign = percentage_sign)
+    }
+    missing_t <- sapply(t, is.null)
+    if (any(missing_t)) {
+      substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
+      names(substitute_t) <- names(t[!missing_t][[1]])
+      t[missing_t][[1]] <- substitute_t
     }
   }
 

--- a/R/getDescriptionStatsBy.R
+++ b/R/getDescriptionStatsBy.R
@@ -87,7 +87,6 @@
 #'  e.g. Smoking; No. 25 observations, where there is a new line after the
 #'  factor name. If you want a different text for the second line you can
 #'  specifically use the \code{\link[base]{sprintf}} formatting, e.g. "No. \%s patients".
-#' @param missing_value Value that is substituted for empty cells. Defaults to "-"  
 #' @param ... Currently only used for generating warnings of deprecated call
 #'  parameters.
 #' @return Returns a vector if vars wasn't specified and it's a
@@ -127,9 +126,8 @@ getDescriptionStatsBy <- function(x,
                                   NEJMstyle = FALSE,
                                   percentage_sign = TRUE,
                                   header_count,
-                                  missing_value = "-",
                                   ...){
-
+  
   API_changes <-
     c(show_missing_digits = "show_missing.digits",
       show_missing = "useNA",
@@ -153,51 +151,51 @@ getDescriptionStatsBy <- function(x,
       }
     }
   }
-
+  
   useNA <- match.arg(useNA)
-
+  
   if (!is.function(statistics)){
     if (is.list(statistics) ||
         (statistics != FALSE)){
-        if (is.list(statistics)){
-          types <- c("continuous",
-                     "proportion",
-                     "factor")
-          if (any(!names(statistics) %in% types))
-            stop("If you want to provide custom functions for generating statistics",
-                 " you must either provide a function or a list with the elements:",
-                 " '", paste(types, collapse="', '"), "'")
-          
-          if (is.numeric(x) &&
-              length(unique(x)) != 2){
-            statistics <- statistics[["continuous"]]
-          }else if (length(unique(x)) == 2){
-            if ("proportion" %in% names(statistics)){
-              statistics <- statistics[["proportion"]]
-            }else{
-              statistics <- statistics[["factor"]]
-            }
+      if (is.list(statistics)){
+        types <- c("continuous",
+                   "proportion",
+                   "factor")
+        if (any(!names(statistics) %in% types))
+          stop("If you want to provide custom functions for generating statistics",
+               " you must either provide a function or a list with the elements:",
+               " '", paste(types, collapse="', '"), "'")
+        
+        if (is.numeric(x) &&
+            length(unique(x)) != 2){
+          statistics <- statistics[["continuous"]]
+        }else if (length(unique(x)) == 2){
+          if ("proportion" %in% names(statistics)){
+            statistics <- statistics[["proportion"]]
           }else{
             statistics <- statistics[["factor"]]
           }
-          
-          if (is.character(statistics))
-            statistics <- get(statistics)
+        }else{
+          statistics <- statistics[["factor"]]
         }
         
-        if (!is.function(statistics)){
-          if(length(unique(x)) == 2){
-            statistics <- getPvalFisher
-          }else if(is.numeric(x)){
-            if (length(unique(by)) == 2)
-              statistics <- getPvalWilcox
-            else
-              statistics <- getPvalAnova
-          }else{
-            statistics <- getPvalFisher
-          }
+        if (is.character(statistics))
+          statistics <- get(statistics)
+      }
+      
+      if (!is.function(statistics)){
+        if(length(unique(x)) == 2){
+          statistics <- getPvalFisher
+        }else if(is.numeric(x)){
+          if (length(unique(by)) == 2)
+            statistics <- getPvalWilcox
+          else
+            statistics <- getPvalAnova
+        }else{
+          statistics <- getPvalFisher
         }
       }
+    }
   }
   
   if (is.function(statistics)){
@@ -212,14 +210,14 @@ getDescriptionStatsBy <- function(x,
                    by = by)
     }
   }
-
+  
   # Always have a total column if the description statistics
   # are presented in a horizontal fashion
   if (missing(add_total_col) &&
-        hrzl_prop){
+      hrzl_prop){
     add_total_col = TRUE
   }
-
+  
   if(is.null(x))
     stop("You haven't provided an x-value to do the statistics by.",
          " This error is most frequently caused by referencing an old",
@@ -228,7 +226,7 @@ getDescriptionStatsBy <- function(x,
     stop("You haven't provided a by-value to do the statistics by.",
          " This error is most frequently caused by referencing an old",
          " variable name that doesn't exist anymore")
-
+  
   # If there is a label for the variable
   # that one should be used otherwise go
   # with the name of the variable
@@ -236,10 +234,10 @@ getDescriptionStatsBy <- function(x,
     name <- deparse(substitute(x))
   else
     name <- label(x)
-
+  
   if (is.logical(x))
     x <- factor(x, levels=c(TRUE, FALSE))
-
+  
   # Check missing -
   # Send a warning, since the user might be unaware of this
   # potentially disturbing fact. The dataset should perhaps by
@@ -256,16 +254,16 @@ getDescriptionStatsBy <- function(x,
       by <- factor(by)
     }
   }
-
+  
   if (useNA == "ifany" &&
-        any(is.na(x)))
+      any(is.na(x)))
     useNA <- "always"
-
+  
   # If all values are to be shown then simply use
   # the factors function
   if (show_all_values)
     prop_fn <- describeFactors
-
+  
   addEmptyValuesToMakeListCompatibleWithMatrix <- function(t){
     # Convert the list into a list with vectors instead of matrices
     for (n in names(t)){
@@ -275,7 +273,7 @@ getDescriptionStatsBy <- function(x,
         names(t[[n]]) <- tmp_names
       }
     }
-
+    
     # TODO: This function does not respect the order in
     # the factored variable. This could potentially be
     # a problem although probably more theoretical
@@ -283,17 +281,17 @@ getDescriptionStatsBy <- function(x,
     for (n in names(t)){
       all_row_names <- union(all_row_names, names(t[[n]]))
     }
-
+    
     # No rownames exist, this occurs often
     # when there is only one row and that row doesn't
     # have a name
     if (is.null(all_row_names))
       return(t)
-
+    
     # The missing NA element should always be last
     if (any(is.na(all_row_names)))
       all_row_names <- append(all_row_names[is.na(all_row_names) == FALSE], NA)
-
+    
     ret <- list()
     for (n in names(t)){
       # Create an empty array
@@ -310,10 +308,10 @@ getDescriptionStatsBy <- function(x,
         }
       }
     }
-
+    
     return(ret)
   }
-
+  
   if (is.numeric(x)){
     # If the numeric has horizontal_proportions then it's only so in the
     # missing category
@@ -330,7 +328,7 @@ getDescriptionStatsBy <- function(x,
               useNA = useNA,
               useNA.digits = useNA.digits,
               percentage_sign = percentage_sign)
-
+    
     missing_t <- sapply(t, is.null)
     if (any(missing_t)) {
       substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
@@ -347,22 +345,22 @@ getDescriptionStatsBy <- function(x,
       else
         names(t[[1]][1]) = fn_name
     }
-
-
+    
+    
   }else if((!is.factor(x) &&
-              length(unique(na.omit(x))) == 2) ||
-             (is.factor(x) &&
-                length(levels(x)) == 2) &&
-             hrzl_prop == FALSE){
-
+            length(unique(na.omit(x))) == 2) ||
+           (is.factor(x) &&
+            length(levels(x)) == 2) &&
+           hrzl_prop == FALSE){
+    
     default_ref <- prDescGetAndValidateDefaultRef(x, default_ref)
-
+    
     t <- by(x, by, FUN=prop_fn, html=html, digits=digits,
             number_first=numbers_first,
             useNA = useNA,
             useNA.digits = useNA.digits,
             default_ref = default_ref, percentage_sign = percentage_sign)
-
+    
     missing_t <- sapply(t, is.null)
     if (any(missing_t)) {
       substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
@@ -378,25 +376,25 @@ getDescriptionStatsBy <- function(x,
       name <- sprintf("%s %s",
                       capitalize(levels(x)[default_ref]),
                       tolower(name))
-
+    
     if (NEJMstyle) {
       # LaTeX needs an escape before %
       # or it marks the rest of the line as
       # a comment. This is not an issue with
       # html (markdown)
       percent_sign <- ifelse(html, "%", "\\%")
-
+      
       if (numbers_first)
         name <- sprintf("%s - no (%s)", name, percent_sign)
       else
         name <- sprintf("%s - %s (no)", name, percent_sign)
     }
-
+    
     # If this is the only row then set that row to the current name
     if (length(t[[1]]) == 1){
       names(t[[1]][1]) = name
     }
-
+    
   }else{
     if (hrzl_prop){
       t <- by(x, by, FUN=factor_fn, html=html, digits=digits,
@@ -412,26 +410,28 @@ getDescriptionStatsBy <- function(x,
               useNA.digits = useNA.digits,
               percentage_sign = percentage_sign)
     }
-    missing_t <- sapply(t, is.null)
-    if (any(missing_t)) {
-      substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
-      names(substitute_t) <- names(t[!missing_t][[1]])
-      t[missing_t][[1]] <- substitute_t
-    }
   }
+  
+  missing_t <- sapply(t, is.null)
+  if (any(missing_t)) {
+    substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
+    names(substitute_t) <- names(t[!missing_t][[1]])
+    t[missing_t][[1]] <- substitute_t
+  }
+}
 
   # Convert the list into a matrix compatible format
   t <- addEmptyValuesToMakeListCompatibleWithMatrix(t)
   # Convert into a matrix
   results <- matrix(unlist(t), ncol=length(t))
-
-
+  
+  
   getHeader <- function (tbl_cnt, header_count, html) {
     if (missing(header_count) ||
-          identical(header_count, FALSE)){
+        identical(header_count, FALSE)){
       return(names(tbl_cnt))
     }
-
+    
     if (is.character(header_count)){
       if (!grepl("%s", header_count, fixed = TRUE))
         stop("Your header_count must accept a string character",
@@ -440,33 +440,33 @@ getDescriptionStatsBy <- function(x,
       cnt_str <-
         sprintf(header_count,
                 txtInt(tbl_cnt))
-
+      
     }else{
       cnt_str <- paste("No.", txtInt(tbl_cnt))
     }
-
+    
     return(mapply(txtMergeLines,
                   names(tbl_cnt),
                   cnt_str,
                   html=html))
   }
-
+  
   cn <- getHeader(table(by), header_count, html)
-
-
+  
+  
   # Add the proper rownames
   if (class(t[[1]]) == "matrix")
     rownames(results) <- rownames(t[[1]])
   else
     rownames(results) <- names(t[[1]])
-
+  
   # This is an effect from the numeric variable not having
   # a naming function
   if (is.null(rownames(results)) && nrow(results) == 1)
     rownames(results) <- name
-
+  
   if (!missing(add_total_col) &&
-        add_total_col != FALSE){
+      add_total_col != FALSE){
     total_table <- prGetStatistics(x[is.na(by) == FALSE],
                                    numbers_first=numbers_first,
                                    show_perc=total_col_show_perc,
@@ -479,18 +479,18 @@ getDescriptionStatsBy <- function(x,
                                    factor_fn = factor_fn,
                                    prop_fn = prop_fn,
                                    percentage_sign = percentage_sign)
-
+    
     if (!is.matrix(total_table)){
       total_table <- matrix(total_table, ncol=1, dimnames=list(names(total_table)))
     }
-
+    
     if (nrow(total_table) != nrow(results)){
       stop("There is a discrepancy in the number of rows in the total table",
            " and the by results: ", nrow(total_table), " total vs ", nrow(results), " results",
            "\n Rows total:", paste(rownames(total_table), collapse=", "),
            "\n Rows results:", paste(rownames(results), collapse=", "))
     }
-
+    
     cn_tot <- getHeader(c(Total=length(x[is.na(by) == FALSE])),
                         header_count, html)
     if (add_total_col != "last"){
@@ -501,7 +501,7 @@ getDescriptionStatsBy <- function(x,
       cn <- c(cn, cn_tot)
     }
   }
-
+  
   if (isTRUE(use_units)){
     if (units(x) != ""){
       unitcol <- rep(sprintf("%s",units(x)), times=NROW(results))
@@ -522,7 +522,7 @@ getDescriptionStatsBy <- function(x,
       name <- sprintf("%s (%s)", name, units(x))
     }
   }
-
+  
   if (is.function(statistics)){
     if (is.numeric(pval) &&
         pval <= 1 &&
@@ -540,13 +540,13 @@ getDescriptionStatsBy <- function(x,
       stop("Your statistics function should either return a numerical value from 0 to 1 or a character with the attribute 'colname'")
     }
   }
-
+  
   colnames(results) <- cn
-
+  
   # Even if one row has the same name this doesn't matter
   # at this stage as it is information that may or may
   # not be used later on
   label(results) <- name
-
+  
   return (results)
 }

--- a/R/getDescriptionStatsBy.R
+++ b/R/getDescriptionStatsBy.R
@@ -87,7 +87,9 @@
 #'  e.g. Smoking; No. 25 observations, where there is a new line after the
 #'  factor name. If you want a different text for the second line you can
 #'  specifically use the \code{\link[base]{sprintf}} formatting, e.g. "No. \%s patients".
-#' @param missing_value Value that is substituted for empty cells. Defaults to "-"  
+#' @param missing_value Value that is substituted for empty cells. Defaults to "-"
+#' @param names_of_missing Optional character vector containing the names of returned statistics,
+#'  in case all returned values for a given \code{by} level are missing. Defaults to NULL
 #' @param ... Currently only used for generating warnings of deprecated call
 #'  parameters.
 #' @return Returns a vector if vars wasn't specified and it's a
@@ -128,6 +130,7 @@ getDescriptionStatsBy <- function(x,
                                   percentage_sign = TRUE,
                                   header_count,
                                   missing_value = "-",
+                                  names_of_missing = NULL,
                                   ...){
 
   API_changes <-
@@ -338,6 +341,17 @@ getDescriptionStatsBy <- function(x,
       t[missing_t][[1]] <- substitute_t
     }
     
+    if (all(sapply(t, is.na)) & !is.null(names_of_missing)) {
+      substitute_t <- rep(missing_value, length(names_of_missing))
+      names(substitute_t) <- names_of_missing
+      substitute_list <- vector("list", length = length(t))
+      names(substitute_list) <- names(t)
+      for (i in seq_along(substitute_list)) {
+        substitute_list[[i]] <- substitute_t
+      }
+      t <- substitute_list
+    }
+    
     if (length(t[[1]]) != 1){
       fn_name <- deparse(substitute(continuous_fn))
       if (fn_name == "describeMean")
@@ -368,6 +382,17 @@ getDescriptionStatsBy <- function(x,
       substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
       names(substitute_t) <- names(t[!missing_t][[1]])
       t[missing_t][[1]] <- substitute_t
+    }
+    
+    if (all(sapply(t, is.na)) & !is.null(names_of_missing)) {
+      substitute_t <- rep(missing_value, length(names_of_missing))
+      names(substitute_t) <- names_of_missing
+      substitute_list <- vector("list", length = length(t))
+      names(substitute_list) <- names(t)
+      for (i in seq_along(substitute_list)) {
+        substitute_list[[i]] <- substitute_t
+      }
+      t <- substitute_list
     }
     
     # Check that we're dealing with only one row
@@ -417,6 +442,17 @@ getDescriptionStatsBy <- function(x,
       substitute_t <- rep(missing_value, length(t[!missing_t][[1]]))
       names(substitute_t) <- names(t[!missing_t][[1]])
       t[missing_t][[1]] <- substitute_t
+    }
+    
+    if (all(sapply(t, is.na)) & !is.null(names_of_missing)) {
+      substitute_t <- rep(missing_value, length(names_of_missing))
+      names(substitute_t) <- names_of_missing
+      substitute_list <- vector("list", length = length(t))
+      names(substitute_list) <- names(t)
+      for (i in seq_along(substitute_list)) {
+        substitute_list[[i]] <- substitute_t
+      }
+      t <- substitute_list
     }
   }
 

--- a/man/getDescriptionStatsBy.Rd
+++ b/man/getDescriptionStatsBy.Rd
@@ -11,7 +11,8 @@ getDescriptionStatsBy(x, by, digits = 1, html = TRUE,
   continuous_fn = describeMean, prop_fn = describeProp,
   factor_fn = describeFactors, show_all_values = FALSE, hrzl_prop = FALSE,
   add_total_col, total_col_show_perc = TRUE, use_units = FALSE, default_ref,
-  NEJMstyle = FALSE, percentage_sign = TRUE, header_count, ...)
+  NEJMstyle = FALSE, percentage_sign = TRUE, header_count,
+  missing_value = "-", ...)
 }
 \arguments{
 \item{x}{The variable that you want the statistics for}
@@ -99,6 +100,8 @@ the default \% if you so wish by setting this variable.}
 e.g. Smoking; No. 25 observations, where there is a new line after the
 factor name. If you want a different text for the second line you can
 specifically use the \code{\link[base]{sprintf}} formatting, e.g. "No. \%s patients".}
+
+\item{missing_value}{Value that is substituted for empty cells. Defaults to "-"}
 
 \item{...}{Currently only used for generating warnings of deprecated call
 parameters.}

--- a/man/getDescriptionStatsBy.Rd
+++ b/man/getDescriptionStatsBy.Rd
@@ -12,7 +12,7 @@ getDescriptionStatsBy(x, by, digits = 1, html = TRUE,
   factor_fn = describeFactors, show_all_values = FALSE, hrzl_prop = FALSE,
   add_total_col, total_col_show_perc = TRUE, use_units = FALSE, default_ref,
   NEJMstyle = FALSE, percentage_sign = TRUE, header_count,
-  missing_value = "-", ...)
+  missing_value = "-", names_of_missing = NULL, ...)
 }
 \arguments{
 \item{x}{The variable that you want the statistics for}
@@ -102,6 +102,9 @@ factor name. If you want a different text for the second line you can
 specifically use the \code{\link[base]{sprintf}} formatting, e.g. "No. \%s patients".}
 
 \item{missing_value}{Value that is substituted for empty cells. Defaults to "-"}
+
+\item{names_of_missing}{Optional character vector containing the names of returned statistics,
+in case all returned values for a given \code{by} level are missing. Defaults to NULL}
 
 \item{...}{Currently only used for generating warnings of deprecated call
 parameters.}

--- a/tests/testthat/test-getDescriptionStats.R
+++ b/tests/testthat/test-getDescriptionStats.R
@@ -528,6 +528,7 @@ test_that("missing levels are handled correctly when using custom descriptive fu
                       outcome = rnorm(40))
   trial_missing_first <- trial[!((trial$visit == "randomisation") & (trial$arm == "control")),]
   trial_missing_second <- trial[!((trial$visit == "randomisation") & (trial$arm == "treatment")),]
+  trial_missing_both <- trial[trial$visit != "week3",]
   
   descriptive_function <- function(x, ...) {
     result <- c(describeMean(x, ...),
@@ -606,6 +607,29 @@ test_that("missing levels are handled correctly when using custom descriptive fu
       .Names = c("rgroup", "n.rgroup")),
     class = c("descMrg", "matrix"))
   
+  expected_missing_both <- structure(
+    c("0.1 (&plusmn;0.7)", "0.2 (-0.5 - 0.5)", "0.1 (&plusmn;0.5)", 
+      "0.2 (-0.2 - 0.5)", "0.4 (&plusmn;1.2)", "0.8 (-0.4 - 1.3)", 
+      "-", "-", "0.1 (&plusmn;1.5)", "0.5 (-0.4 - 1.0)", "-0.2 (&plusmn;0.8)", 
+      "-0.2 (-0.7 - 0.3)", "-0.5 (&plusmn;1.2)", "-0.1 (-0.6 - 0.1)", 
+      "-", "-"),
+    .Dim = c(8L, 2L),
+    .Dimnames = list(c("Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)"),
+                     c("control", "treatment")),
+    rgroup = c("trial_missing_both$outcome[trial_missing_both$visit == x]",
+               "trial_missing_both$outcome[trial_missing_both$visit == x]",
+               "trial_missing_both$outcome[trial_missing_both$visit == x]", 
+               "trial_missing_both$outcome[trial_missing_both$visit == x]"),
+    n.rgroup = c(2L, 2L, 2L, 2L),
+    htmlTable_args = structure(list(
+      rgroup = c("randomisation", "week1", "week2", "week3"),
+      n.rgroup = c(2, 2, 2, 2)),
+      .Names = c("rgroup", "n.rgroup")),
+    class = c("descMrg", "matrix"))
+  
   out <- mergeDesc(lapply(levels(trial$visit), function(x)
     getDescriptionStatsBy(x = trial$outcome[trial$visit == x],
                           by = trial$arm[trial$visit == x],
@@ -629,4 +653,13 @@ test_that("missing levels are handled correctly when using custom descriptive fu
     htmlTable_args = list(rgroup = levels(trial_missing_second$visit),
                           n.rgroup = rep(2, 4)))
   expect_identical(out, expected_missing_second)
+  
+    out <- mergeDesc(lapply(levels(trial_missing_both$visit), function(x)
+    getDescriptionStatsBy(x = trial_missing_both$outcome[trial_missing_both$visit == x],
+                          by = trial_missing_both$arm[trial_missing_both$visit == x],
+                          continuous_fn = descriptive_function,
+                          names_of_missing = c("Mean (SD)", "Median (IQR)"))),
+    htmlTable_args = list(rgroup = levels(trial_missing_both$visit),
+                          n.rgroup = rep(2, 4)))
+  expect_identical(out, expected_missing_both)
 })

--- a/tests/testthat/test-getDescriptionStats.R
+++ b/tests/testthat/test-getDescriptionStats.R
@@ -17,119 +17,119 @@ Loblolly$height_w_missing <- Loblolly$height
 Loblolly$height_w_missing[sample(1:nrow(Loblolly), size=4)] <- NA
 
 test_that("Check mean function",
-{
-  stats <- by(Loblolly$height, Loblolly$young, mean)
-  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
-                             statistics=TRUE,
-                             digits=2, statistics.sig_lim=10^-4)
-  # Check that it contains the true mean
-  expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
-              info="Expected the mean")
-  expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
-              info="Expected the mean")
-
-  # Check that it contains the sd
-  stats <- by(Loblolly$height, Loblolly$young, sd)
-  expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
-              info="Expected the sd")
-  expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
-              info="Expected the sd")
-
-  true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
-                          statistics.sig_lim=10^-4)
-  expect_equal(as.character(a[1, "P-value"]),
-               true_wilc_pv)
-
-  # Check P-value without truncation
-  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$age == 10,
-                             statistics=TRUE,
-                             digits=2, statistics.sig_lim=10^-4)
-  true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$age == 10)$p.value,
-                          statistics.sig_lim=10^-4)
-  expect_equal(as.character(a[1, "P-value"]),
-               true_wilc_pv)
-})
+          {
+            stats <- by(Loblolly$height, Loblolly$young, mean)
+            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
+                                       statistics=TRUE,
+                                       digits=2, statistics.sig_lim=10^-4)
+            # Check that it contains the true mean
+            expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
+                        info="Expected the mean")
+            expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
+                        info="Expected the mean")
+            
+            # Check that it contains the sd
+            stats <- by(Loblolly$height, Loblolly$young, sd)
+            expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
+                        info="Expected the sd")
+            expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
+                        info="Expected the sd")
+            
+            true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
+                                    statistics.sig_lim=10^-4)
+            expect_equal(as.character(a[1, "P-value"]),
+                         true_wilc_pv)
+            
+            # Check P-value without truncation
+            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$age == 10,
+                                       statistics=TRUE,
+                                       digits=2, statistics.sig_lim=10^-4)
+            true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$age == 10)$p.value,
+                                    statistics.sig_lim=10^-4)
+            expect_equal(as.character(a[1, "P-value"]),
+                         true_wilc_pv)
+          })
 
 test_that("Check median function",
-{
-  stats <- by(Loblolly$height, Loblolly$young, median)
-  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
-                             continuous_fn=describeMedian,
-                             statistics=TRUE,
-                             digits=2, statistics.sig_lim=10^-4)
-  # Check that it contains the true mean
-  expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
-              info="Expected the median")
-  expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
-              info="Expected the median")
-
-  # Check that it contains the sd
-  stats <- by(Loblolly$height, Loblolly$young,
-              function(x) str_trim(paste(format(quantile(x, probs=c(.25, .75)),
-                                                digits=2,
-                                                nsmall=2), collapse=" - ")))
-  expect_true(grepl(stats[["No"]], a[1,"No"]),
-              info="Expected the iqr range")
-  expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
-              info="Expected the iqr range")
-
-  true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
-                                  statistics.sig_lim=10^-4)
-  expect_equal(as.character(a[1, "P-value"]),
-               true_wilc_pv)
-
-  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
-                             continuous_fn=function(...)
-                               describeMedian(..., iqr = FALSE),
-                             statistics=TRUE,
-                             digits=2, statistics.sig_lim=10^-4)
-
-  # Check that it contains the sd
-  stats <- by(Loblolly$height, Loblolly$young,
-              function(x) paste(round(range(x), 2), collapse=" - "))
-  expect_true(grepl(stats[["No"]], a[1,"No"]),
-              info="Expected the range")
-  expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
-              info="Expected the range")
-})
+          {
+            stats <- by(Loblolly$height, Loblolly$young, median)
+            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
+                                       continuous_fn=describeMedian,
+                                       statistics=TRUE,
+                                       digits=2, statistics.sig_lim=10^-4)
+            # Check that it contains the true mean
+            expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
+                        info="Expected the median")
+            expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
+                        info="Expected the median")
+            
+            # Check that it contains the sd
+            stats <- by(Loblolly$height, Loblolly$young,
+                        function(x) str_trim(paste(format(quantile(x, probs=c(.25, .75)),
+                                                          digits=2,
+                                                          nsmall=2), collapse=" - ")))
+            expect_true(grepl(stats[["No"]], a[1,"No"]),
+                        info="Expected the iqr range")
+            expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
+                        info="Expected the iqr range")
+            
+            true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
+                                    statistics.sig_lim=10^-4)
+            expect_equal(as.character(a[1, "P-value"]),
+                         true_wilc_pv)
+            
+            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
+                                       continuous_fn=function(...)
+                                         describeMedian(..., iqr = FALSE),
+                                       statistics=TRUE,
+                                       digits=2, statistics.sig_lim=10^-4)
+            
+            # Check that it contains the sd
+            stats <- by(Loblolly$height, Loblolly$young,
+                        function(x) paste(round(range(x), 2), collapse=" - "))
+            expect_true(grepl(stats[["No"]], a[1,"No"]),
+                        info="Expected the range")
+            expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
+                        info="Expected the range")
+          })
 
 test_that("Check factor function",
-{
-  stats <- table(Loblolly$fvar, Loblolly$young)
-  a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
-                             continuous_fn=describeMedian,
-                             statistics=TRUE,
-                             digits=2, statistics.sig_lim=10^-4)
-  # Check that it contains the true mean
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young))
-      expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                   info="Factor count don't match")
-  }
-
-  vertical_perc_stats <- format(apply(stats, 2, function(x){
-    x/sum(x)*100
-  }), nsmall=2, digits=2)
-  horizontal_perc_stats <- t(format(apply(stats, 1, function(x){
-    x/sum(x)*100
-  }), nsmall=2, digits=2))
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young))
-      expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
-                  info="Factor percentagess don't match in vertical mode")
-  }
-
-  a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
-                             continuous_fn=describeMedian,
-                             statistics=TRUE,
-                             digits=2, statistics.sig_lim=10^-4)
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young))
-      expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
-                  info="Factor percentagess don't match in horizontal mode")
-  }
-
-})
+          {
+            stats <- table(Loblolly$fvar, Loblolly$young)
+            a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
+                                       continuous_fn=describeMedian,
+                                       statistics=TRUE,
+                                       digits=2, statistics.sig_lim=10^-4)
+            # Check that it contains the true mean
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young))
+                expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                             info="Factor count don't match")
+            }
+            
+            vertical_perc_stats <- format(apply(stats, 2, function(x){
+              x/sum(x)*100
+            }), nsmall=2, digits=2)
+            horizontal_perc_stats <- t(format(apply(stats, 1, function(x){
+              x/sum(x)*100
+            }), nsmall=2, digits=2))
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young))
+                expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
+                             info="Factor percentagess don't match in vertical mode")
+            }
+            
+            a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
+                                       continuous_fn=describeMedian,
+                                       statistics=TRUE,
+                                       digits=2, statistics.sig_lim=10^-4)
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young))
+                expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
+                             info="Factor percentagess don't match in horizontal mode")
+            }
+            
+          })
 
 test_that("Statistics work as expected",{
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
@@ -142,7 +142,7 @@ test_that("Statistics work as expected",{
   
   expect_equivalent(as.character(a[1, "P-value"]),
                     true_fisher_pval)
-
+  
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
                              continuous_fn=describeMedian,
                              statistics=list("factor" = getPvalFisher),
@@ -150,7 +150,7 @@ test_that("Statistics work as expected",{
   
   expect_equivalent(as.character(a[1, "P-value"]),
                     true_fisher_pval)
-
+  
   expect_error(getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
                                      continuous_fn=describeMedian,
                                      statistics=list("factor" = getNonExistentPvalueFunction),
@@ -185,7 +185,7 @@ test_that("Statistics work as expected",{
                                        return(a)
                                      },
                                      digits=2, statistics.sig_lim=10^-4),
-                info = "The colname attribute must be present")
+               info = "The colname attribute must be present")
 })
 
 test_that("Check total column position",{
@@ -196,7 +196,7 @@ test_that("Check total column position",{
                              digits=2, statistics.sig_lim=10^-4)
   expect_equivalent(colnames(a)[1], "Total")
   expect_equivalent(ncol(a), 4)
-
+  
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
                              hrzl_prop=TRUE,
                              add_total_col = "last",
@@ -205,7 +205,7 @@ test_that("Check total column position",{
   expect_equivalent(tail(colnames(a),1), "Total",
                     info="The last column without statistics should be the total column when the add_total_col is set to last")
   expect_equivalent(ncol(a), 3)
-
+  
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
                              statistics = TRUE,
                              hrzl_prop=TRUE,
@@ -216,119 +216,119 @@ test_that("Check total column position",{
 })
 
 test_that("Check factor function with missing",
-{
-  stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="ifany")
-  expect_warning(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
-                                            statistics=TRUE,
-                                            digits=2, statistics.sig_lim=10^-4))
-
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young))
-      expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                   info="Factor count don't match")
-  }
-
-
-  stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="no")
-  vertical_perc_stats <-
-    format(apply(stats, 2, function(x){
-      x/sum(x)*100
-    }), nsmall=2, digits=2)
-  horizontal_perc_stats <-
-    t(format(apply(stats, 1, function(x){
-      x/sum(x)*100
-    }), nsmall=2, digits=2))
-
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young))
-      expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
-                  info="Factor vertical percentages don't match")
-  }
-
-  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
-                                              hrzl_prop=TRUE,
-                                              statistics=TRUE,
-                                              digits=2, statistics.sig_lim=10^-4))
-
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young))
-      expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
-                  info="Factor percentages don't match in horizontal mode")
-  }
-
-  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing,
-                                              useNA="no",
-                                              digits=2, statistics.sig_lim=10^-4))
-  stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="no")
-  vertical_perc_stats <-
-    format(apply(stats, 2, function(x){
-      x/sum(x)*100
-    }), nsmall=2, digits=2)
-
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young)){
-      expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                  info=sprintf("Factor '%s':'%s' count don't match",
-                               rn, cn))
-      expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
-                   info=sprintf("Factor '%s':'%s' vertical percentages don't match",
-                                rn, cn))
-    }
-  }
-
-  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing,
-                                              Loblolly$young_w_missing,
-                                              digits=2, statistics.sig_lim=10^-4))
-  stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="ifany")
-  stats <- stats[,!is.na(colnames(stats))]
-  rownames(stats)[is.na(rownames(stats))] <- "Missing"
-  vertical_perc_stats <-
-    format(apply(stats, 2, function(x){
-      x/sum(x)*100
-    }), nsmall=2, digits=2)
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young)){
-      expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                   info=sprintf("Factor '%s':'%s' count don't match",
-                                rn, cn))
-      expect_match(a[rn, cn], sprintf("%s%%", str_trim(vertical_perc_stats[rn, cn])),
-                   info=sprintf("Factor '%s':'%s' vertical percentages don't match",
-                                rn, cn))
-    }
-  }
-
-  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing, hrzl_prop = TRUE,
-                             digits=2, statistics.sig_lim=10^-4))
-  horizontal_perc_stats <-
-    t(format(apply(stats, 1, function(x){
-      x/sum(x)*100
-    }), nsmall=2, digits=2))
-
-
-  for (rn in rownames(a)){
-    for (cn in levels(Loblolly$young)){
-      expect_match(a[rn, cn], sprintf("%s%%", str_trim(horizontal_perc_stats[rn, cn])),
-                  info="Factor vertical percentages don't match")
-    }
-  }
-
-  # When
-  # - `x` has exactly 2 levels and some NAs
-  # - add_total_col=TRUE
-  # - show_missing="no"
-  # - show_all_values=FALSE
-  # Then prGetStatistics should return the count of just the first factor level
-  # use example:
-  #   a <- getDescriptionStatsBy(Loblolly$young_w_missing, Loblolly$fvar,
-  #                              useNA="no", digits=2,
-  #                              add_total_col=TRUE)
-  a <- prGetStatistics(Loblolly$young_w_missing,
-                       useNA ="no", show_all_values=FALSE)
-  lvl = levels(Loblolly$young_w_missing)[1]
-  target = sum(stats[, lvl])
-  names(target) = lvl
-  expect_equal(a, target)
-})
+          {
+            stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="ifany")
+            expect_warning(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
+                                                      statistics=TRUE,
+                                                      digits=2, statistics.sig_lim=10^-4))
+            
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young))
+                expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                             info="Factor count don't match")
+            }
+            
+            
+            stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="no")
+            vertical_perc_stats <-
+              format(apply(stats, 2, function(x){
+                x/sum(x)*100
+              }), nsmall=2, digits=2)
+            horizontal_perc_stats <-
+              t(format(apply(stats, 1, function(x){
+                x/sum(x)*100
+              }), nsmall=2, digits=2))
+            
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young))
+                expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
+                             info="Factor vertical percentages don't match")
+            }
+            
+            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
+                                                        hrzl_prop=TRUE,
+                                                        statistics=TRUE,
+                                                        digits=2, statistics.sig_lim=10^-4))
+            
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young))
+                expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
+                             info="Factor percentages don't match in horizontal mode")
+            }
+            
+            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing,
+                                                        useNA="no",
+                                                        digits=2, statistics.sig_lim=10^-4))
+            stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="no")
+            vertical_perc_stats <-
+              format(apply(stats, 2, function(x){
+                x/sum(x)*100
+              }), nsmall=2, digits=2)
+            
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young)){
+                expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                             info=sprintf("Factor '%s':'%s' count don't match",
+                                          rn, cn))
+                expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
+                             info=sprintf("Factor '%s':'%s' vertical percentages don't match",
+                                          rn, cn))
+              }
+            }
+            
+            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing,
+                                                        Loblolly$young_w_missing,
+                                                        digits=2, statistics.sig_lim=10^-4))
+            stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="ifany")
+            stats <- stats[,!is.na(colnames(stats))]
+            rownames(stats)[is.na(rownames(stats))] <- "Missing"
+            vertical_perc_stats <-
+              format(apply(stats, 2, function(x){
+                x/sum(x)*100
+              }), nsmall=2, digits=2)
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young)){
+                expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                             info=sprintf("Factor '%s':'%s' count don't match",
+                                          rn, cn))
+                expect_match(a[rn, cn], sprintf("%s%%", str_trim(vertical_perc_stats[rn, cn])),
+                             info=sprintf("Factor '%s':'%s' vertical percentages don't match",
+                                          rn, cn))
+              }
+            }
+            
+            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing, hrzl_prop = TRUE,
+                                                        digits=2, statistics.sig_lim=10^-4))
+            horizontal_perc_stats <-
+              t(format(apply(stats, 1, function(x){
+                x/sum(x)*100
+              }), nsmall=2, digits=2))
+            
+            
+            for (rn in rownames(a)){
+              for (cn in levels(Loblolly$young)){
+                expect_match(a[rn, cn], sprintf("%s%%", str_trim(horizontal_perc_stats[rn, cn])),
+                             info="Factor vertical percentages don't match")
+              }
+            }
+            
+            # When
+            # - `x` has exactly 2 levels and some NAs
+            # - add_total_col=TRUE
+            # - show_missing="no"
+            # - show_all_values=FALSE
+            # Then prGetStatistics should return the count of just the first factor level
+            # use example:
+            #   a <- getDescriptionStatsBy(Loblolly$young_w_missing, Loblolly$fvar,
+            #                              useNA="no", digits=2,
+            #                              add_total_col=TRUE)
+            a <- prGetStatistics(Loblolly$young_w_missing,
+                                 useNA ="no", show_all_values=FALSE)
+            lvl = levels(Loblolly$young_w_missing)[1]
+            target = sum(stats[, lvl])
+            names(target) = lvl
+            expect_equal(a, target)
+          })
 
 test_that("Check txtInt application",{
   # Check for factors
@@ -361,19 +361,19 @@ test_that("Error when one category has no missing in it", {
   aa[aaa == 2 & is.na(aa)] <- "B"
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa, add_total_col = TRUE)
-
+  
   expect_match(ret["A","2"], sprintf("^%d", table(aa, aaa)["A","2"]),
                info="The value does not seem to match the raw table")
   expect_match(ret["B","2"], sprintf("^%d", table(aa, aaa)["B","2"]),
                info="The value does not seem to match the raw table")
   expect_match(ret["Missing","2"], "^0")
-
+  
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa, useNA="no", add_total_col = TRUE)
   expect_match(ret[1,"2"], sprintf("^%d", table(aa, aaa)["A","2"]),
                info="The value does not seem to match the raw table")
   expect_equal(nrow(ret), 1)
-
+  
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa,
                           add_total_col = TRUE,
@@ -383,14 +383,14 @@ test_that("Error when one category has no missing in it", {
                info="The value does not seem to match the raw table")
   expect_match(ret["B","2"], sprintf("^%d", table(aa, aaa)["B","2"]),
                info="The value does not seem to match the raw table")
-
+  
   cont <- rnorm(length(aa))
   cont[sample(1:50, size = 5)] <- NA
   cont[aaa == 2 & is.na(cont)] <- 0
   ret <-
     getDescriptionStatsBy(x = cont, by=aaa, useNA="no", add_total_col = TRUE)
   expect_equal(nrow(ret), 1)
-
+  
   aa <- factor(sample(LETTERS[1:3], size = 50, replace = TRUE))
   aa[sample(1:50, size = 5)] <- NA
   aaa <- factor(sample(1:2, size = 50, replace = TRUE))
@@ -401,8 +401,8 @@ test_that("Error when one category has no missing in it", {
                info="The value does not seem to match the raw table")
   expect_match(ret["B","2"], sprintf("^%d", table(aa, aaa)["B","2"]),
                info="The value does not seem to match the raw table")
-
-
+  
+  
 })
 
 test_that("Error when one continuous variable has no missing in it", {
@@ -413,7 +413,7 @@ test_that("Error when one continuous variable has no missing in it", {
   aa[aaa == 2 & is.na(aa)] <- 1
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa, html=TRUE)
-
+  
   expect_match(ret["Missing","2"],
                sprintf("^%d", sum(is.na(aa[aaa == 2]))))
 })
@@ -426,7 +426,7 @@ test_that("Error when a factor variable has an empty level", {
   by <- factor(sample(1:2, size = 50, replace = TRUE))
   ret <-
     getDescriptionStatsBy(x = variable, by=by, add_total_col = TRUE, useNA="no")
-
+  
   expect_match(ret["B","2"],
                sprintf("^%d", sum(variable[by == 2] == "B", na.rm=TRUE)))
 })
@@ -434,13 +434,13 @@ test_that("Error when a factor variable has an empty level", {
 
 test_that("test header", {
   data(mtcars)
-
+  
   mtcars$am <- factor(mtcars$am, levels=0:1, labels=c("Automatic", "Manual"))
   Hmisc::label(mtcars$am) <- "Transmission"
   set.seed(666)
   mtcars$col <- factor(sample(c("red", "black", "silver"),
                               size=NROW(mtcars), replace=TRUE))
-
+  
   out <- getDescriptionStatsBy(
     x=mtcars$col,
     by=mtcars$am,
@@ -456,8 +456,8 @@ test_that("test header", {
   expect_match(colnames(out)[3],
                sprintf("No. %d",
                        sum(mtcars$am != levels(mtcars$am)[1])))
-
-
+  
+  
   out <- getDescriptionStatsBy(
     x=mtcars$col,
     by=mtcars$am,
@@ -465,7 +465,7 @@ test_that("test header", {
     add_total_col = TRUE,
     statistics = TRUE
   )
-
+  
   expect_match(colnames(out)[1],
                sprintf("\\(n = %d\\)", nrow(mtcars)))
   expect_match(colnames(out)[2],
@@ -493,7 +493,7 @@ test_that("Test use_units", {
       add_total_col = TRUE,
       statistics = TRUE
     ))
-
+  
   out2 <- suppressWarnings(
     getDescriptionStatsBy(
       x=mtcars$mpg,
@@ -506,7 +506,7 @@ test_that("Test use_units", {
   )
   
   expect_equal(ncol(out1) + 1, ncol(out2))
-
+  
   out3 <- suppressWarnings(
     getDescriptionStatsBy(
       x=mtcars$mpg,
@@ -519,4 +519,114 @@ test_that("Test use_units", {
   )
   expect_match(Hmisc::label(out3), "\\(mpg\\)")
   expect_false(grepl("\\(mpg\\)", label(out2)))
+})
+
+test_that("missing levels are handled correctly when using custom descriptive functions", {
+  set.seed(1)
+  trial <- data.frame(visit = sort(rep(c("randomisation", "week1", "week2", "week3"), 5)),
+                      arm = sort(rep(c("control", "treatment"))),
+                      outcome = rnorm(40))
+  trial_missing_first <- trial[!((trial$visit == "randomisation") & (trial$arm == "control")),]
+  trial_missing_second <- trial[!((trial$visit == "randomisation") & (trial$arm == "treatment")),]
+  
+  descriptive_function <- function(x, ...) {
+    result <- c(describeMean(x, ...),
+                describeMedian(x, ...))
+    return(result)
+  }
+  
+  expected_no_missing <- structure(
+    c("0.1 (&plusmn;0.7)", "0.2 (-0.5 - 0.5)", "0.1 (&plusmn;0.5)", 
+      "0.2 (-0.2 - 0.5)", "0.4 (&plusmn;1.2)", "0.8 (-0.4 - 1.3)", 
+      "0.4 (&plusmn;0.7)", "0.4 (-0.1 - 0.9)", "0.1 (&plusmn;1.5)", 
+      "0.5 (-0.4 - 1.0)", "-0.2 (&plusmn;0.8)", "-0.2 (-0.7 - 0.3)", 
+      "-0.5 (&plusmn;1.2)", "-0.1 (-0.6 - 0.1)", "0.3 (&plusmn;0.5)", 
+      "0.3 (-0.1 - 0.7)"),
+    .Dim = c(8L, 2L),
+    .Dimnames = list(c("Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)"),
+                     c("control", "treatment")),
+    rgroup = c("trial$outcome[trial$visit == x]",
+               "trial$outcome[trial$visit == x]",
+               "trial$outcome[trial$visit == x]",
+               "trial$outcome[trial$visit == x]"),
+    n.rgroup = c(2L, 2L, 2L, 2L),
+    htmlTable_args = structure(list(
+      rgroup = c("randomisation", "week1", "week2", "week3"),
+      n.rgroup = c(2, 2, 2, 2)),
+      .Names = c("rgroup", "n.rgroup")),
+    class = c("descMrg", "matrix"))
+  
+  expected_missing_first <- structure(
+    c("-", "-", "0.1 (&plusmn;0.5)", "0.2 (-0.2 - 0.5)", 
+      "0.4 (&plusmn;1.2)", "0.8 (-0.4 - 1.3)", "0.4 (&plusmn;0.7)", 
+      "0.4 (-0.1 - 0.9)", "0.1 (&plusmn;1.5)", "0.5 (-0.4 - 1.0)", 
+      "-0.2 (&plusmn;0.8)", "-0.2 (-0.7 - 0.3)", "-0.5 (&plusmn;1.2)", 
+      "-0.1 (-0.6 - 0.1)", "0.3 (&plusmn;0.5)", "0.3 (-0.1 - 0.7)"),
+    .Dim = c(8L, 2L),
+    .Dimnames = list(c("Mean (SD)", "Median (IQR)", 
+                       "Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)",
+                       "Mean (SD)", "Median (IQR)"),
+                     c("control", "treatment")),
+    rgroup = c("trial_missing_first$outcome[trial_missing_first$visit == x]", 
+               "trial_missing_first$outcome[trial_missing_first$visit == x]", 
+               "trial_missing_first$outcome[trial_missing_first$visit == x]", 
+               "trial_missing_first$outcome[trial_missing_first$visit == x]"),
+    n.rgroup = c(2L, 2L, 2L, 2L),
+    htmlTable_args = structure(list(
+      rgroup = c("randomisation", "week1", "week2", "week3"),
+      n.rgroup = c(2, 2, 2, 2)),
+      .Names = c("rgroup", "n.rgroup")),
+    class = c("descMrg", "matrix"))
+  
+  expected_missing_second <- structure(
+    c("0.1 (&plusmn;0.7)", "0.2 (-0.5 - 0.5)", "0.1 (&plusmn;0.5)", 
+      "0.2 (-0.2 - 0.5)", "0.4 (&plusmn;1.2)", "0.8 (-0.4 - 1.3)", 
+      "0.4 (&plusmn;0.7)", "0.4 (-0.1 - 0.9)", "-", "-", "-0.2 (&plusmn;0.8)", 
+      "-0.2 (-0.7 - 0.3)", "-0.5 (&plusmn;1.2)", "-0.1 (-0.6 - 0.1)", 
+      "0.3 (&plusmn;0.5)", "0.3 (-0.1 - 0.7)"),
+    .Dim = c(8L, 2L),
+    .Dimnames = list(
+      c("Mean (SD)", "Median (IQR)",
+        "Mean (SD)", "Median (IQR)", 
+        "Mean (SD)", "Median (IQR)",
+        "Mean (SD)", "Median (IQR)"), 
+      c("control", "treatment")),
+    rgroup = c("trial_missing_second$outcome[trial_missing_second$visit == x]", 
+               "trial_missing_second$outcome[trial_missing_second$visit == x]", 
+               "trial_missing_second$outcome[trial_missing_second$visit == x]", 
+               "trial_missing_second$outcome[trial_missing_second$visit == x]"),
+    n.rgroup = c(2L, 2L, 2L, 2L),
+    htmlTable_args = structure(list(
+      rgroup = c("randomisation", "week1", "week2", "week3"),
+      n.rgroup = c(2, 2, 2, 2)),
+      .Names = c("rgroup", "n.rgroup")),
+    class = c("descMrg", "matrix"))
+  
+  out <- mergeDesc(lapply(levels(trial$visit), function(x)
+    getDescriptionStatsBy(x = trial$outcome[trial$visit == x],
+                          by = trial$arm[trial$visit == x],
+                          continuous_fn = descriptive_function)),
+    htmlTable_args = list(rgroup = levels(trial$visit),
+                          n.rgroup = rep(2, 4)))
+  expect_identical(out, expected_no_missing)
+  
+  out <- mergeDesc(lapply(levels(trial_missing_first$visit), function(x)
+    getDescriptionStatsBy(x = trial_missing_first$outcome[trial_missing_first$visit == x],
+                          by = trial_missing_first$arm[trial_missing_first$visit == x],
+                          continuous_fn = descriptive_function)),
+    htmlTable_args = list(rgroup = levels(trial_missing_first$visit),
+                          n.rgroup = rep(2, 4)))
+  expect_identical(out, expected_missing_first)
+  
+  out <- mergeDesc(lapply(levels(trial_missing_second$visit), function(x)
+    getDescriptionStatsBy(x = trial_missing_second$outcome[trial_missing_second$visit == x],
+                          by = trial_missing_second$arm[trial_missing_second$visit == x],
+                          continuous_fn = descriptive_function)),
+    htmlTable_args = list(rgroup = levels(trial_missing_second$visit),
+                          n.rgroup = rep(2, 4)))
+  expect_identical(out, expected_missing_second)
 })

--- a/tests/testthat/test-getDescriptionStats.R
+++ b/tests/testthat/test-getDescriptionStats.R
@@ -17,119 +17,119 @@ Loblolly$height_w_missing <- Loblolly$height
 Loblolly$height_w_missing[sample(1:nrow(Loblolly), size=4)] <- NA
 
 test_that("Check mean function",
-          {
-            stats <- by(Loblolly$height, Loblolly$young, mean)
-            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
-                                       statistics=TRUE,
-                                       digits=2, statistics.sig_lim=10^-4)
-            # Check that it contains the true mean
-            expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
-                        info="Expected the mean")
-            expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
-                        info="Expected the mean")
-            
-            # Check that it contains the sd
-            stats <- by(Loblolly$height, Loblolly$young, sd)
-            expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
-                        info="Expected the sd")
-            expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
-                        info="Expected the sd")
-            
-            true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
-                                    statistics.sig_lim=10^-4)
-            expect_equal(as.character(a[1, "P-value"]),
-                         true_wilc_pv)
-            
-            # Check P-value without truncation
-            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$age == 10,
-                                       statistics=TRUE,
-                                       digits=2, statistics.sig_lim=10^-4)
-            true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$age == 10)$p.value,
-                                    statistics.sig_lim=10^-4)
-            expect_equal(as.character(a[1, "P-value"]),
-                         true_wilc_pv)
-          })
+{
+  stats <- by(Loblolly$height, Loblolly$young, mean)
+  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
+                             statistics=TRUE,
+                             digits=2, statistics.sig_lim=10^-4)
+  # Check that it contains the true mean
+  expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
+              info="Expected the mean")
+  expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
+              info="Expected the mean")
+
+  # Check that it contains the sd
+  stats <- by(Loblolly$height, Loblolly$young, sd)
+  expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
+              info="Expected the sd")
+  expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
+              info="Expected the sd")
+
+  true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
+                          statistics.sig_lim=10^-4)
+  expect_equal(as.character(a[1, "P-value"]),
+               true_wilc_pv)
+
+  # Check P-value without truncation
+  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$age == 10,
+                             statistics=TRUE,
+                             digits=2, statistics.sig_lim=10^-4)
+  true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$age == 10)$p.value,
+                          statistics.sig_lim=10^-4)
+  expect_equal(as.character(a[1, "P-value"]),
+               true_wilc_pv)
+})
 
 test_that("Check median function",
-          {
-            stats <- by(Loblolly$height, Loblolly$young, median)
-            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
-                                       continuous_fn=describeMedian,
-                                       statistics=TRUE,
-                                       digits=2, statistics.sig_lim=10^-4)
-            # Check that it contains the true mean
-            expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
-                        info="Expected the median")
-            expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
-                        info="Expected the median")
-            
-            # Check that it contains the sd
-            stats <- by(Loblolly$height, Loblolly$young,
-                        function(x) str_trim(paste(format(quantile(x, probs=c(.25, .75)),
-                                                          digits=2,
-                                                          nsmall=2), collapse=" - ")))
-            expect_true(grepl(stats[["No"]], a[1,"No"]),
-                        info="Expected the iqr range")
-            expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
-                        info="Expected the iqr range")
-            
-            true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
-                                    statistics.sig_lim=10^-4)
-            expect_equal(as.character(a[1, "P-value"]),
-                         true_wilc_pv)
-            
-            a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
-                                       continuous_fn=function(...)
-                                         describeMedian(..., iqr = FALSE),
-                                       statistics=TRUE,
-                                       digits=2, statistics.sig_lim=10^-4)
-            
-            # Check that it contains the sd
-            stats <- by(Loblolly$height, Loblolly$young,
-                        function(x) paste(round(range(x), 2), collapse=" - "))
-            expect_true(grepl(stats[["No"]], a[1,"No"]),
-                        info="Expected the range")
-            expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
-                        info="Expected the range")
-          })
+{
+  stats <- by(Loblolly$height, Loblolly$young, median)
+  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
+                             continuous_fn=describeMedian,
+                             statistics=TRUE,
+                             digits=2, statistics.sig_lim=10^-4)
+  # Check that it contains the true mean
+  expect_true(grepl(round(stats[["No"]], 2), a[1,"No"]),
+              info="Expected the median")
+  expect_true(grepl(round(stats[["Yes"]], 2), a[1,"Yes"]),
+              info="Expected the median")
+
+  # Check that it contains the sd
+  stats <- by(Loblolly$height, Loblolly$young,
+              function(x) str_trim(paste(format(quantile(x, probs=c(.25, .75)),
+                                                digits=2,
+                                                nsmall=2), collapse=" - ")))
+  expect_true(grepl(stats[["No"]], a[1,"No"]),
+              info="Expected the iqr range")
+  expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
+              info="Expected the iqr range")
+
+  true_wilc_pv <- txtPval(wilcox.test(Loblolly$height ~ Loblolly$young)$p.value,
+                                  statistics.sig_lim=10^-4)
+  expect_equal(as.character(a[1, "P-value"]),
+               true_wilc_pv)
+
+  a <- getDescriptionStatsBy(Loblolly$height, Loblolly$young,
+                             continuous_fn=function(...)
+                               describeMedian(..., iqr = FALSE),
+                             statistics=TRUE,
+                             digits=2, statistics.sig_lim=10^-4)
+
+  # Check that it contains the sd
+  stats <- by(Loblolly$height, Loblolly$young,
+              function(x) paste(round(range(x), 2), collapse=" - "))
+  expect_true(grepl(stats[["No"]], a[1,"No"]),
+              info="Expected the range")
+  expect_true(grepl(stats[["Yes"]], a[1,"Yes"]),
+              info="Expected the range")
+})
 
 test_that("Check factor function",
-          {
-            stats <- table(Loblolly$fvar, Loblolly$young)
-            a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
-                                       continuous_fn=describeMedian,
-                                       statistics=TRUE,
-                                       digits=2, statistics.sig_lim=10^-4)
-            # Check that it contains the true mean
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young))
-                expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                             info="Factor count don't match")
-            }
-            
-            vertical_perc_stats <- format(apply(stats, 2, function(x){
-              x/sum(x)*100
-            }), nsmall=2, digits=2)
-            horizontal_perc_stats <- t(format(apply(stats, 1, function(x){
-              x/sum(x)*100
-            }), nsmall=2, digits=2))
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young))
-                expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
-                             info="Factor percentagess don't match in vertical mode")
-            }
-            
-            a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
-                                       continuous_fn=describeMedian,
-                                       statistics=TRUE,
-                                       digits=2, statistics.sig_lim=10^-4)
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young))
-                expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
-                             info="Factor percentagess don't match in horizontal mode")
-            }
-            
-          })
+{
+  stats <- table(Loblolly$fvar, Loblolly$young)
+  a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
+                             continuous_fn=describeMedian,
+                             statistics=TRUE,
+                             digits=2, statistics.sig_lim=10^-4)
+  # Check that it contains the true mean
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young))
+      expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                   info="Factor count don't match")
+  }
+
+  vertical_perc_stats <- format(apply(stats, 2, function(x){
+    x/sum(x)*100
+  }), nsmall=2, digits=2)
+  horizontal_perc_stats <- t(format(apply(stats, 1, function(x){
+    x/sum(x)*100
+  }), nsmall=2, digits=2))
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young))
+      expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
+                  info="Factor percentagess don't match in vertical mode")
+  }
+
+  a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
+                             continuous_fn=describeMedian,
+                             statistics=TRUE,
+                             digits=2, statistics.sig_lim=10^-4)
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young))
+      expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
+                  info="Factor percentagess don't match in horizontal mode")
+  }
+
+})
 
 test_that("Statistics work as expected",{
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
@@ -142,7 +142,7 @@ test_that("Statistics work as expected",{
   
   expect_equivalent(as.character(a[1, "P-value"]),
                     true_fisher_pval)
-  
+
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
                              continuous_fn=describeMedian,
                              statistics=list("factor" = getPvalFisher),
@@ -150,7 +150,7 @@ test_that("Statistics work as expected",{
   
   expect_equivalent(as.character(a[1, "P-value"]),
                     true_fisher_pval)
-  
+
   expect_error(getDescriptionStatsBy(Loblolly$fvar, Loblolly$young, hrzl_prop=TRUE,
                                      continuous_fn=describeMedian,
                                      statistics=list("factor" = getNonExistentPvalueFunction),
@@ -185,7 +185,7 @@ test_that("Statistics work as expected",{
                                        return(a)
                                      },
                                      digits=2, statistics.sig_lim=10^-4),
-               info = "The colname attribute must be present")
+                info = "The colname attribute must be present")
 })
 
 test_that("Check total column position",{
@@ -196,7 +196,7 @@ test_that("Check total column position",{
                              digits=2, statistics.sig_lim=10^-4)
   expect_equivalent(colnames(a)[1], "Total")
   expect_equivalent(ncol(a), 4)
-  
+
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
                              hrzl_prop=TRUE,
                              add_total_col = "last",
@@ -205,7 +205,7 @@ test_that("Check total column position",{
   expect_equivalent(tail(colnames(a),1), "Total",
                     info="The last column without statistics should be the total column when the add_total_col is set to last")
   expect_equivalent(ncol(a), 3)
-  
+
   a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young,
                              statistics = TRUE,
                              hrzl_prop=TRUE,
@@ -216,119 +216,119 @@ test_that("Check total column position",{
 })
 
 test_that("Check factor function with missing",
-          {
-            stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="ifany")
-            expect_warning(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
-                                                      statistics=TRUE,
-                                                      digits=2, statistics.sig_lim=10^-4))
-            
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young))
-                expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                             info="Factor count don't match")
-            }
-            
-            
-            stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="no")
-            vertical_perc_stats <-
-              format(apply(stats, 2, function(x){
-                x/sum(x)*100
-              }), nsmall=2, digits=2)
-            horizontal_perc_stats <-
-              t(format(apply(stats, 1, function(x){
-                x/sum(x)*100
-              }), nsmall=2, digits=2))
-            
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young))
-                expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
-                             info="Factor vertical percentages don't match")
-            }
-            
-            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
-                                                        hrzl_prop=TRUE,
-                                                        statistics=TRUE,
-                                                        digits=2, statistics.sig_lim=10^-4))
-            
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young))
-                expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
-                             info="Factor percentages don't match in horizontal mode")
-            }
-            
-            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing,
-                                                        useNA="no",
-                                                        digits=2, statistics.sig_lim=10^-4))
-            stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="no")
-            vertical_perc_stats <-
-              format(apply(stats, 2, function(x){
-                x/sum(x)*100
-              }), nsmall=2, digits=2)
-            
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young)){
-                expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                             info=sprintf("Factor '%s':'%s' count don't match",
-                                          rn, cn))
-                expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
-                             info=sprintf("Factor '%s':'%s' vertical percentages don't match",
-                                          rn, cn))
-              }
-            }
-            
-            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing,
-                                                        Loblolly$young_w_missing,
-                                                        digits=2, statistics.sig_lim=10^-4))
-            stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="ifany")
-            stats <- stats[,!is.na(colnames(stats))]
-            rownames(stats)[is.na(rownames(stats))] <- "Missing"
-            vertical_perc_stats <-
-              format(apply(stats, 2, function(x){
-                x/sum(x)*100
-              }), nsmall=2, digits=2)
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young)){
-                expect_match(a[rn, cn], as.character(stats[rn, cn]),
-                             info=sprintf("Factor '%s':'%s' count don't match",
-                                          rn, cn))
-                expect_match(a[rn, cn], sprintf("%s%%", str_trim(vertical_perc_stats[rn, cn])),
-                             info=sprintf("Factor '%s':'%s' vertical percentages don't match",
-                                          rn, cn))
-              }
-            }
-            
-            suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing, hrzl_prop = TRUE,
-                                                        digits=2, statistics.sig_lim=10^-4))
-            horizontal_perc_stats <-
-              t(format(apply(stats, 1, function(x){
-                x/sum(x)*100
-              }), nsmall=2, digits=2))
-            
-            
-            for (rn in rownames(a)){
-              for (cn in levels(Loblolly$young)){
-                expect_match(a[rn, cn], sprintf("%s%%", str_trim(horizontal_perc_stats[rn, cn])),
-                             info="Factor vertical percentages don't match")
-              }
-            }
-            
-            # When
-            # - `x` has exactly 2 levels and some NAs
-            # - add_total_col=TRUE
-            # - show_missing="no"
-            # - show_all_values=FALSE
-            # Then prGetStatistics should return the count of just the first factor level
-            # use example:
-            #   a <- getDescriptionStatsBy(Loblolly$young_w_missing, Loblolly$fvar,
-            #                              useNA="no", digits=2,
-            #                              add_total_col=TRUE)
-            a <- prGetStatistics(Loblolly$young_w_missing,
-                                 useNA ="no", show_all_values=FALSE)
-            lvl = levels(Loblolly$young_w_missing)[1]
-            target = sum(stats[, lvl])
-            names(target) = lvl
-            expect_equal(a, target)
-          })
+{
+  stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="ifany")
+  expect_warning(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
+                                            statistics=TRUE,
+                                            digits=2, statistics.sig_lim=10^-4))
+
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young))
+      expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                   info="Factor count don't match")
+  }
+
+
+  stats <- table(Loblolly$fvar, Loblolly$young_w_missing, useNA="no")
+  vertical_perc_stats <-
+    format(apply(stats, 2, function(x){
+      x/sum(x)*100
+    }), nsmall=2, digits=2)
+  horizontal_perc_stats <-
+    t(format(apply(stats, 1, function(x){
+      x/sum(x)*100
+    }), nsmall=2, digits=2))
+
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young))
+      expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
+                  info="Factor vertical percentages don't match")
+  }
+
+  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar, Loblolly$young_w_missing,
+                                              hrzl_prop=TRUE,
+                                              statistics=TRUE,
+                                              digits=2, statistics.sig_lim=10^-4))
+
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young))
+      expect_match(a[rn, cn], sprintf("%s%%", horizontal_perc_stats[rn, cn]),
+                  info="Factor percentages don't match in horizontal mode")
+  }
+
+  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing,
+                                              useNA="no",
+                                              digits=2, statistics.sig_lim=10^-4))
+  stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="no")
+  vertical_perc_stats <-
+    format(apply(stats, 2, function(x){
+      x/sum(x)*100
+    }), nsmall=2, digits=2)
+
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young)){
+      expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                  info=sprintf("Factor '%s':'%s' count don't match",
+                               rn, cn))
+      expect_match(a[rn, cn], sprintf("%s%%", vertical_perc_stats[rn, cn]),
+                   info=sprintf("Factor '%s':'%s' vertical percentages don't match",
+                                rn, cn))
+    }
+  }
+
+  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing,
+                                              Loblolly$young_w_missing,
+                                              digits=2, statistics.sig_lim=10^-4))
+  stats <- table(Loblolly$fvar_w_missing, Loblolly$young_w_missing, useNA="ifany")
+  stats <- stats[,!is.na(colnames(stats))]
+  rownames(stats)[is.na(rownames(stats))] <- "Missing"
+  vertical_perc_stats <-
+    format(apply(stats, 2, function(x){
+      x/sum(x)*100
+    }), nsmall=2, digits=2)
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young)){
+      expect_match(a[rn, cn], as.character(stats[rn, cn]),
+                   info=sprintf("Factor '%s':'%s' count don't match",
+                                rn, cn))
+      expect_match(a[rn, cn], sprintf("%s%%", str_trim(vertical_perc_stats[rn, cn])),
+                   info=sprintf("Factor '%s':'%s' vertical percentages don't match",
+                                rn, cn))
+    }
+  }
+
+  suppressWarnings(a <- getDescriptionStatsBy(Loblolly$fvar_w_missing, Loblolly$young_w_missing, hrzl_prop = TRUE,
+                             digits=2, statistics.sig_lim=10^-4))
+  horizontal_perc_stats <-
+    t(format(apply(stats, 1, function(x){
+      x/sum(x)*100
+    }), nsmall=2, digits=2))
+
+
+  for (rn in rownames(a)){
+    for (cn in levels(Loblolly$young)){
+      expect_match(a[rn, cn], sprintf("%s%%", str_trim(horizontal_perc_stats[rn, cn])),
+                  info="Factor vertical percentages don't match")
+    }
+  }
+
+  # When
+  # - `x` has exactly 2 levels and some NAs
+  # - add_total_col=TRUE
+  # - show_missing="no"
+  # - show_all_values=FALSE
+  # Then prGetStatistics should return the count of just the first factor level
+  # use example:
+  #   a <- getDescriptionStatsBy(Loblolly$young_w_missing, Loblolly$fvar,
+  #                              useNA="no", digits=2,
+  #                              add_total_col=TRUE)
+  a <- prGetStatistics(Loblolly$young_w_missing,
+                       useNA ="no", show_all_values=FALSE)
+  lvl = levels(Loblolly$young_w_missing)[1]
+  target = sum(stats[, lvl])
+  names(target) = lvl
+  expect_equal(a, target)
+})
 
 test_that("Check txtInt application",{
   # Check for factors
@@ -361,19 +361,19 @@ test_that("Error when one category has no missing in it", {
   aa[aaa == 2 & is.na(aa)] <- "B"
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa, add_total_col = TRUE)
-  
+
   expect_match(ret["A","2"], sprintf("^%d", table(aa, aaa)["A","2"]),
                info="The value does not seem to match the raw table")
   expect_match(ret["B","2"], sprintf("^%d", table(aa, aaa)["B","2"]),
                info="The value does not seem to match the raw table")
   expect_match(ret["Missing","2"], "^0")
-  
+
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa, useNA="no", add_total_col = TRUE)
   expect_match(ret[1,"2"], sprintf("^%d", table(aa, aaa)["A","2"]),
                info="The value does not seem to match the raw table")
   expect_equal(nrow(ret), 1)
-  
+
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa,
                           add_total_col = TRUE,
@@ -383,14 +383,14 @@ test_that("Error when one category has no missing in it", {
                info="The value does not seem to match the raw table")
   expect_match(ret["B","2"], sprintf("^%d", table(aa, aaa)["B","2"]),
                info="The value does not seem to match the raw table")
-  
+
   cont <- rnorm(length(aa))
   cont[sample(1:50, size = 5)] <- NA
   cont[aaa == 2 & is.na(cont)] <- 0
   ret <-
     getDescriptionStatsBy(x = cont, by=aaa, useNA="no", add_total_col = TRUE)
   expect_equal(nrow(ret), 1)
-  
+
   aa <- factor(sample(LETTERS[1:3], size = 50, replace = TRUE))
   aa[sample(1:50, size = 5)] <- NA
   aaa <- factor(sample(1:2, size = 50, replace = TRUE))
@@ -401,8 +401,8 @@ test_that("Error when one category has no missing in it", {
                info="The value does not seem to match the raw table")
   expect_match(ret["B","2"], sprintf("^%d", table(aa, aaa)["B","2"]),
                info="The value does not seem to match the raw table")
-  
-  
+
+
 })
 
 test_that("Error when one continuous variable has no missing in it", {
@@ -413,7 +413,7 @@ test_that("Error when one continuous variable has no missing in it", {
   aa[aaa == 2 & is.na(aa)] <- 1
   ret <-
     getDescriptionStatsBy(x = aa, by=aaa, html=TRUE)
-  
+
   expect_match(ret["Missing","2"],
                sprintf("^%d", sum(is.na(aa[aaa == 2]))))
 })
@@ -426,7 +426,7 @@ test_that("Error when a factor variable has an empty level", {
   by <- factor(sample(1:2, size = 50, replace = TRUE))
   ret <-
     getDescriptionStatsBy(x = variable, by=by, add_total_col = TRUE, useNA="no")
-  
+
   expect_match(ret["B","2"],
                sprintf("^%d", sum(variable[by == 2] == "B", na.rm=TRUE)))
 })
@@ -434,13 +434,13 @@ test_that("Error when a factor variable has an empty level", {
 
 test_that("test header", {
   data(mtcars)
-  
+
   mtcars$am <- factor(mtcars$am, levels=0:1, labels=c("Automatic", "Manual"))
   Hmisc::label(mtcars$am) <- "Transmission"
   set.seed(666)
   mtcars$col <- factor(sample(c("red", "black", "silver"),
                               size=NROW(mtcars), replace=TRUE))
-  
+
   out <- getDescriptionStatsBy(
     x=mtcars$col,
     by=mtcars$am,
@@ -456,8 +456,8 @@ test_that("test header", {
   expect_match(colnames(out)[3],
                sprintf("No. %d",
                        sum(mtcars$am != levels(mtcars$am)[1])))
-  
-  
+
+
   out <- getDescriptionStatsBy(
     x=mtcars$col,
     by=mtcars$am,
@@ -465,7 +465,7 @@ test_that("test header", {
     add_total_col = TRUE,
     statistics = TRUE
   )
-  
+
   expect_match(colnames(out)[1],
                sprintf("\\(n = %d\\)", nrow(mtcars)))
   expect_match(colnames(out)[2],
@@ -493,7 +493,7 @@ test_that("Test use_units", {
       add_total_col = TRUE,
       statistics = TRUE
     ))
-  
+
   out2 <- suppressWarnings(
     getDescriptionStatsBy(
       x=mtcars$mpg,
@@ -506,7 +506,7 @@ test_that("Test use_units", {
   )
   
   expect_equal(ncol(out1) + 1, ncol(out2))
-  
+
   out3 <- suppressWarnings(
     getDescriptionStatsBy(
       x=mtcars$mpg,
@@ -520,7 +520,6 @@ test_that("Test use_units", {
   expect_match(Hmisc::label(out3), "\\(mpg\\)")
   expect_false(grepl("\\(mpg\\)", label(out2)))
 })
-
 test_that("missing levels are handled correctly when using custom descriptive functions", {
   set.seed(1)
   trial <- data.frame(visit = sort(rep(c("randomisation", "week1", "week2", "week3"), 5)),

--- a/tests/testthat/test-getDescriptionStats.R
+++ b/tests/testthat/test-getDescriptionStats.R
@@ -520,6 +520,7 @@ test_that("Test use_units", {
   expect_match(Hmisc::label(out3), "\\(mpg\\)")
   expect_false(grepl("\\(mpg\\)", label(out2)))
 })
+
 test_that("missing levels are handled correctly when using custom descriptive functions", {
   set.seed(1)
   trial <- data.frame(visit = sort(rep(c("randomisation", "week1", "week2", "week3"), 5)),


### PR DESCRIPTION
Hi Max,

this is an attempt to fix the easy case of issue #21. My code closely resembled yours, except that it attempts to assign the correct names and length to an empty cell. I added a silent argument used to fill missing cells, defaulting to "-", but I guess you could set it to NA (for me that would require an extra acronym in the table footer, as required by our style guidelines). 

Thanks for considering this,
Peter.