### PR TITLE
Use describeFactors for proportions in getDescriptionStatsBy if all values are to be shown

### DIFF
--- a/R/getDescriptionStatsBy.R
+++ b/R/getDescriptionStatsBy.R
@@ -268,8 +268,8 @@ getDescriptionStatsBy <- function(x,
     useNA <- "always"
 
   # If all values are to be shown then simply use
-  # the factors function
-  if (show_all_values)
+  # the factors function, provided describeProp was specified
+  if (show_all_values & deparse(substitute(prop_fn)) == "describeProp")
     prop_fn <- describeFactors
 
   addEmptyValuesToMakeListCompatibleWithMatrix <- function(t){


### PR DESCRIPTION
Use `describeFactors` for proportions if all values are to be shown, provided the default `describeProp` was specified. This prevents `getDescriptionStatsBy` from overriding a user-specified description function when `show_all_values = TRUE`. Fixes issue #26.