### PR TITLE
Realign assert_just with the expected format

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -52,8 +52,8 @@ assert_just <- function(var, allow_missing = TRUE){
     return()
 
   assert(
-    checkString(var, pattern = "left|right|top|bottom|center"),
-    checkNumeric(var, lower = 0, upper = 1),
+    checkCharacter(var, pattern = "^left|right|top|bottom|center|centre$", max.len = 2),
+    checkNumeric(var, lower = 0, upper = 1, max.len = 2),
     .var.name = dep_var(var)
   )
 }


### PR DESCRIPTION
`assert_just` is used to check that justification specifications have the correct format. It's used on values that will go to the `just` option of either `grid::viewport()` or `grid::grobText()`. Both of these [describe](https://www.rdocumentation.org/packages/grid/versions/3.6.2/topics/Grid%20Viewports) the expected format as:

> A string or numeric vector specifying the justification of the viewport relative to its (x, y) location. If there are two values, the first value specifies horizontal justification and the second value specifies vertical justification. Possible string values are: "left", "right", "centre", "center", "bottom", and "top". For numeric values, 0 means left alignment and 1 means right alignment.

The problem is that `assert_just` is overly restrictive. It only allows scalar strings when a character vector of length 2 is acceptable. It also doesn't allow the alternative spelling `"centre"`. This change aligns the checks with the expected format, but I wonder if it really makes sense to be checking this at all here when the values are only ever forwarded to grid. Shouldn't it be grid's responsibility?