### PR TITLE
Make connectGrob work with split boxes in "N" mode

### DIFF
--- a/R/boxGrobs_connect.R
+++ b/R/boxGrobs_connect.R
@@ -122,10 +122,10 @@ connectGrob <- function(
     }
 
     line$x <- unit.c(
-      start$x,
-      start$x,
-      end$x,
-      end$x
+      getX4elmnt(start, "x"),
+      getX4elmnt(start, "x"),
+      getX4elmnt(end, "x"),
+      getX4elmnt(end, "x")
     )
   } else if (type == "vertical") {
     line$x <- unit.c(getX4elmnt(start, "x"), getX4elmnt(end, "x"))


### PR DESCRIPTION
When using `connectGrob` with the "N" mode, it would ignore the `subelmnt` argument and always connect arrows to the middle to a split box. This change makes the "N" mode consistent with the others.

Incidentally, I noticed that if you use `connectGrob` when both `start` and `end` are split boxes, there's no way to independently select the subelement for each box since there's just a single `subelmnt` argument. It's simple enough to fix here.