### PR TITLE
Accept any language object in boxGrob label

### DIFF
--- a/R/boxGrobs_boxGrob.R
+++ b/R/boxGrobs_boxGrob.R
@@ -41,7 +41,7 @@ boxGrob <- function(label,
   assert(
     checkString(label),
     checkNumeric(label),
-    is.expression(label)
+    is.language(label)
   )
   assert_unit(y)
   assert_unit(x)


### PR DESCRIPTION
While `expression()` creates an `expression` object, the related `plotmath` functions `substitute()` and `bquote()` return objects of the parent type `language`. The underlying `textGrob` can cope just fine with these objects, so the type check here is overly restrictive.

For example:
```R
library(grid)

a = 5
text = bquote(a == .(a))
grid.newpage()
grid.draw(textGrob(text))
# draws the text "a = 5"
```

With `boxGrob()` a current workaround is to use `as.expression(text)` to allow it to pass the type check. With this change that wouldn't be needed.

I have anecdotal evidence that `langauge` objects with multiple lines of text somehow break the height calculation again, but I haven't worked out how to nicely reproduce it yet. The `plotmath` stuff in R is not exactly intuitive...

Also, `boxPropGrob()` doesn't accept `expression`s or `language` objects at all. Should this type check maybe be moved to `assert_label()` so that both functions can share it?