### PR TITLE
Define STRICT_R_HEADERS, include cfloat, use FLT_EPSILON and M_PI

### DIFF
--- a/inst/include/Gmisc.h
+++ b/inst/include/Gmisc.h
@@ -2,6 +2,7 @@
 # include <iostream>
 # include <iomanip>
 # include <vector>
+# include <cfloat>
 
 struct Point{
   double x;

--- a/src/Gmisc_lines.cpp
+++ b/src/Gmisc_lines.cpp
@@ -1,4 +1,4 @@
-#include "Rcpp.h"
+#include <Rcpp.h>
 #include <Gmisc.h>
 
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,1 @@
-PKG_CPPFLAGS = -I../inst/include/
+PKG_CPPFLAGS = -I../inst/include/ -DSTRICT_R_HEADERS

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,1 @@
-PKG_CPPFLAGS = -I../inst/include/
+PKG_CPPFLAGS = -I../inst/include/ -DSTRICT_R_HEADERS

--- a/src/bezierArrowFn.cpp
+++ b/src/bezierArrowFn.cpp
@@ -22,9 +22,9 @@ Point generatePoint(double offs,
   // Strange things happen around 0
   Point offset_delta = { (p.x - offs_delta * cos_val - last.x),
                          (p.y - offs_delta * sin_val - last.y) };
-  if (fabs(offset_delta.x) < SINGLE_EPS)
+  if (fabs(offset_delta.x) < FLT_EPSILON)
     offset_delta.x = 0;
-  if (fabs(offset_delta.y) < SINGLE_EPS)
+  if (fabs(offset_delta.y) < FLT_EPSILON)
     offset_delta.y = 0;
   
   // Notify that element goes in wrong direction
@@ -125,21 +125,21 @@ Rcpp::List calculateLinesAndArrow(NumericVector x,
         delta.x = (x[ii+1] - x[ii]);
         ii++;
       }while(ii < x.size() &&
-           fabs(delta.x) < SINGLE_EPS &&
-           fabs(delta.y) < SINGLE_EPS);
+           fabs(delta.x) < FLT_EPSILON &&
+           fabs(delta.y) < FLT_EPSILON);
     }
 
     // Strange things happen around 0
-    if (fabs(delta.x) < SINGLE_EPS)
+    if (fabs(delta.x) < FLT_EPSILON)
       delta.x = 0;
-    if (fabs(delta.y) < SINGLE_EPS)
+    if (fabs(delta.y) < FLT_EPSILON)
       delta.y = 0;
 
     angle = atan2(delta.y, delta.x);
 
     Point p = generatePoint(offs,
                       offs_delta,
-                      angle -  PI/2,
+                      angle -  M_PI/2,
                       x[i],
                       y[i],
                       last_right,
@@ -150,7 +150,7 @@ Rcpp::List calculateLinesAndArrow(NumericVector x,
 
     p = generatePoint(offs,
                       offs_delta,
-                      angle +  PI/2,
+                      angle +  M_PI/2,
                       x[i],
                       y[i],
                       last_left,
@@ -164,15 +164,15 @@ Rcpp::List calculateLinesAndArrow(NumericVector x,
   // Add the arrow if requested
   if (arrow_offset > 0){
     // Same angle as last angle
-    left.addPoint(arrow_offset * cos(angle +  PI/2) + x[x.size() - 1],
-                  arrow_offset * sin(angle +  PI/2) + y[x.size() - 1],
+    left.addPoint(arrow_offset * cos(angle +  M_PI/2) + x[x.size() - 1],
+                  arrow_offset * sin(angle +  M_PI/2) + y[x.size() - 1],
                   false);
     left.addPoint(end_x,
                   end_y,
                   false);
 
-    right.addPoint(arrow_offset * cos(angle -  PI/2) + x[x.size() - 1],
-                   arrow_offset * sin(angle -  PI/2) + y[x.size() - 1],
+    right.addPoint(arrow_offset * cos(angle -  M_PI/2) + x[x.size() - 1],
+                   arrow_offset * sin(angle -  M_PI/2) + y[x.size() - 1],
                    false);
     right.addPoint(end_x,
                    end_y,


### PR DESCRIPTION
Hi Max,

Your CRAN package Gmisc uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, instead of prefixing each #include <Rcpp.h> with STRICT_R_HEADERS we define it in src/Makevars* for a more minimal changeset (I think I personally prefer it in each file, but in your case the single joint header is very good too) . The actual change that is needed is the inclusion of cfloat (or float.h, C style) in the header and then a simple change from PI to M_PI, and to FLT_EPSILON in two files.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.